### PR TITLE
Fix mister_bin compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      matrix: { ruby: ['2.7', '3.0', '3.1'] }
+      matrix: { ruby: ['2.7', '3.0', '3.1', '3.2', head] }
 
     steps:
     - name: Checkout code

--- a/sla.gemspec
+++ b/sla.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.required_ruby_version = ">= 2.7.0"
 
-  s.add_dependency 'colsole', '~> 0.7', '>= 0.7.1'
-  s.add_dependency 'mister_bin', '~> 0.7'
-  s.add_dependency 'webcache', '~> 0.7'
+  s.add_dependency 'colsole', '~> 0.7.2'
+  s.add_dependency 'mister_bin', '~> 0.7.3'
+  s.add_dependency 'webcache', '~> 0.8.0'
   s.add_dependency 'nokogiri', '~> 1.10'
 end


### PR DESCRIPTION
The currently published gem will fail due to the fact that syntax has changed in mister_bin.

This PR updates the gemspec with more explicit version requirements.