### PR TITLE
Housekeeping

### DIFF
--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -1,0 +1,28 @@
+name: Docker build (version + latest)
+on:
+  push: { tags: 'v[0-9]+.[0-9]+.[0-9]+' }
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Extract tag
+        run: echo "TAG=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: dannyben/sla,dannyben/sla:${{ env.TAG }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install OS dependencies
       run: sudo apt-get -y install libyaml-dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      matrix: { ruby: ['2.7', '3.0', '3.1', '3.2', head] }
+      matrix: { ruby: ['3.1', '3.2', '3.3'] }
 
     steps:
     - name: Checkout code

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ inherit_gem:
     - rspec.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.1
   Exclude:
     - debug.rb
     - dev/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,10 @@
 source 'https://rubygems.org'
 
-gem 'byebug'
 gem 'colsole'
+gem 'debug'
 gem 'httpme'
 gem 'lp'
+gem 'rackup'
 gem 'rspec'
 gem 'rspec_approvals'
 gem 'runfile'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   sla:
     build: .

--- a/lib/sla.rb
+++ b/lib/sla.rb
@@ -16,10 +16,3 @@ require 'sla/formatters/simple'
 require 'sla/formatters/tty'
 
 require 'sla/command'
-
-if ENV['BYEBUG']
-  # :nocov:
-  require 'byebug'
-  require 'lp'
-  # :nocov:
-end

--- a/sla.gemspec
+++ b/sla.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/DannyBen/sla'
   s.license     = 'MIT'
 
-  s.required_ruby_version = '>= 2.7.0'
+  s.required_ruby_version = '>= 3.1.0'
 
   s.add_dependency 'colsole', '>= 0.8.1', '< 2'
   s.add_dependency 'mister_bin', '~> 0.7'


### PR DESCRIPTION
- Drop support for Ruby <= 3.0
- Add `rackup` as a development dependency (for the mock server)
- Build docker image using a GitHub Actions workflow
- Replace `byebug` with `debug` and remove conditional loading in non-development code
